### PR TITLE
Hook up league verification to identity manager

### DIFF
--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueConnect.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueConnect.java
@@ -5,6 +5,8 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.UUID;
+
 public class CommandLeagueConnect implements CommandExecutor {
     final LeagueIdentityProvider leagueIdentityProvider = new LeagueIdentityProvider();
     
@@ -14,16 +16,19 @@ public class CommandLeagueConnect implements CommandExecutor {
             sender.sendMessage("This command can only be run by a player");
         } else {
             Player player = (Player) sender;
-            String username = player.getName();
-            if (username == null) {
+            UUID playerId = player.getUniqueId();
+            if (playerId == null) {
+                sender.sendMessage("Something went wrong: Player not found :/");
                 return false;
             }
-            String token = leagueIdentityProvider.beginVerification(username);
+            String token = leagueIdentityProvider.beginVerification(playerId);
             if (token == null) {
+                sender.sendMessage("Something went wrong: Verification token couldn't be generated :/");
                 return false;
             }
             
-            player.sendMessage("Please go into League and use this verification token: " + token);
+            player.sendMessage("Log into your League of Legends client, go to Settings -> Verification, and enter the following code: " + token);
+            player.sendMessage("Once you've done that, use the /leagueverify command to finish connecting your Summoner.");
         }
         
         return true;

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueConnect.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueConnect.java
@@ -21,7 +21,7 @@ public class CommandLeagueConnect implements CommandExecutor {
                 sender.sendMessage("Something went wrong: Player not found :/");
                 return false;
             }
-            String token = leagueIdentityProvider.beginVerification(playerId);
+            String token = leagueIdentityProvider.createVerificationToken(playerId);
             if (token == null) {
                 sender.sendMessage("Something went wrong: Verification token couldn't be generated :/");
                 return false;

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 
 import com.merakianalytics.orianna.types.common.Region;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 public class CommandLeagueVerify implements CommandExecutor {
@@ -22,7 +23,23 @@ public class CommandLeagueVerify implements CommandExecutor {
             if (playerId == null) {
                 return false;
             }
-            boolean verified = leagueIdentityProvider.verifyToken(playerId, "WxWatch", Region.NORTH_AMERICA);
+
+            if (args.length == 0 && args.length == 1) {
+                return false;
+            }
+
+            String summonerName = String.join(" ", Arrays.copyOfRange(args, 0, args.length - 1));
+            if (summonerName == null) {
+                return false;
+            }
+
+            String regionString = args[args.length - 1];
+            Region region = getRegion(regionString);
+            if (region == null) {
+                return false;
+            }
+
+            boolean verified = leagueIdentityProvider.verifyToken(playerId, summonerName, region);
             if (verified) {
                 player.sendMessage("Successfully verified!");
             } else {
@@ -31,5 +48,34 @@ public class CommandLeagueVerify implements CommandExecutor {
         }
         
         return true;
+    }
+
+    private Region getRegion(String shortname) {
+        switch (shortname.toLowerCase()) {
+            case "br":
+                return Region.BRAZIL;
+            case "eune":
+                return Region.EUROPE_NORTH_EAST;
+            case "euw":
+                return Region.EUROPE_WEST;
+            case "jp":
+                return Region.JAPAN;
+            case "kr":
+                return Region.KOREA;
+            case "lan":
+                return Region.LATIN_AMERICA_NORTH;
+            case "las":
+                return Region.LATIN_AMERICA_SOUTH;
+            case "na":
+                return Region.NORTH_AMERICA;
+            case "oce":
+                return Region.OCEANIA;
+            case "ru":
+                return Region.RUSSIA;
+            case "tr":
+                return Region.TURKEY;
+            default:
+                return null;
+        }
     }
 }

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
@@ -22,7 +22,7 @@ public class CommandLeagueVerify implements CommandExecutor {
             if (playerId == null) {
                 return false;
             }
-            boolean verified = leagueIdentityProvider.performVerification(playerId, "WxWatch", Region.NORTH_AMERICA);
+            boolean verified = leagueIdentityProvider.verifyToken(playerId, "WxWatch", Region.NORTH_AMERICA);
             if (verified) {
                 player.sendMessage("Successfully verified!");
             } else {

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
@@ -7,6 +7,8 @@ import org.bukkit.entity.Player;
 
 import com.merakianalytics.orianna.types.common.Region;
 
+import java.util.UUID;
+
 public class CommandLeagueVerify implements CommandExecutor {
     final LeagueIdentityProvider leagueIdentityProvider = new LeagueIdentityProvider();
     
@@ -16,11 +18,11 @@ public class CommandLeagueVerify implements CommandExecutor {
             sender.sendMessage("This command can only be run by a player");
         } else {
             Player player = (Player) sender;
-            String username = player.getName();
-            if (username == null) {
+            UUID playerId = player.getUniqueId();
+            if (playerId == null) {
                 return false;
             }
-            boolean verified = leagueIdentityProvider.performVerification(username, "WxWatch", Region.NORTH_AMERICA);
+            boolean verified = leagueIdentityProvider.performVerification(playerId, "WxWatch", Region.NORTH_AMERICA);
             if (verified) {
                 player.sendMessage("Successfully verified!");
             } else {

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/CommandLeagueVerify.java
@@ -24,7 +24,7 @@ public class CommandLeagueVerify implements CommandExecutor {
                 return false;
             }
 
-            if (args.length == 0 && args.length == 1) {
+            if (args.length == 0 || args.length == 1) {
                 return false;
             }
 

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/IdentityManager.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/IdentityManager.java
@@ -2,6 +2,7 @@ package com.hextechsheep.hextech.gateway;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import com.hextechsheep.hextech.persistence.HextechDataStore;
 import com.hextechsheep.hextech.persistence.HextechDataStore.Transaction;
@@ -54,6 +55,8 @@ public class IdentityManager {
             return Summoner.withAccountId(Long.parseLong(accountId)).withPlatform(Platform.withTag(platform)).get();
         }
 
+        public String getLeagueVerifyToken() { return identities.get(LEAGUE_VERIFY_TOKEN); }
+
         public void setMinecraftId(final String minecraftId) {
             if(minecraftId == null) {
                 throw new IllegalArgumentException("minecraft id must not be null!");
@@ -83,11 +86,19 @@ public class IdentityManager {
                 transaction.put(identities.get(MINECRAFT_ID), identities);
             }
         }
+
+        public void setLeagueVerifyToken(final String token) {
+            identities.put(LEAGUE_VERIFY_TOKEN, token);
+            try(Transaction transaction = dataStore.open(tableName)) {
+                transaction.put(identities.get(MINECRAFT_ID), identities);
+            }
+        }
     }
 
     private static final String DEFAULT_TABLE_NAME = "hextech-gateway.identity-manager";
     private static final String LEAGUE_ACCOUNT_ID = "league-account-id";
     private static final String LEAGUE_PLATFORM = "league-platform";
+    private static final String LEAGUE_VERIFY_TOKEN = "league-verify-token";
     private static final String MINECRAFT_ID = "minecraft-id";
     private static final String MINECRAFT_NAME = "minecraft-name";
     private final HextechDataStore dataStore;

--- a/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/LeagueIdentityProvider.java
+++ b/hextech-gateway/src/main/java/com/hextechsheep/hextech/gateway/LeagueIdentityProvider.java
@@ -14,14 +14,14 @@ public class LeagueIdentityProvider {
     }
 
     // Make verification token to give to user
-    public String beginVerification(UUID minecraftId) {
+    public String createVerificationToken(UUID minecraftId) {
         final String token = generateVerificationToken();
         storeVerificationToken(minecraftId, token);
         
         return token;
     }
     
-    public boolean performVerification(UUID minecraftId, String summonerName, Region region) {
+    public boolean verifyToken(UUID minecraftId, String summonerName, Region region) {
         final String token = getVerificationToken(minecraftId);
         final Summoner summoner = Summoner.named(summonerName).withRegion(region).get();
         final VerificationString verification = summoner.getVerificationString();

--- a/hextech-gateway/src/main/resources/plugin.yml
+++ b/hextech-gateway/src/main/resources/plugin.yml
@@ -7,4 +7,4 @@ commands:
       usage: /leagueconnect
    leagueverify:
       description: Verify your League of Legends
-      usage: /leagueverify
+      usage: /leagueverify [Summoner Name] [Region]


### PR DESCRIPTION
This allows a player to use the `/leagueconnect` command to generate a verification code for their LoL client, and `/leagueverify` to verify that they've entered the code correctly, and stores their summoner. 

I don't like those command names, so we should come up with new ones and change them eventually.